### PR TITLE
Prevent fail in case of changed mandatory params

### DIFF
--- a/matrix-build-server/src/main/java/com/presidentio/teamcity/matrix/build/server/MatrixBuildRunTypePropertiesProcessor.java
+++ b/matrix-build-server/src/main/java/com/presidentio/teamcity/matrix/build/server/MatrixBuildRunTypePropertiesProcessor.java
@@ -82,6 +82,8 @@ public class MatrixBuildRunTypePropertiesProcessor implements PropertiesProcesso
             properties.load(new StringReader(map.get(SettingsConst.PROP_CONST_BUILD_PARAMETERS)));
         } catch (IOException e) {
             result.add(new InvalidProperty(SettingsConst.PROP_CONST_BUILD_PARAMETERS, Dictionary.ERROR_INVALID_PROPERTIES));
+        } catch (NullPointerException e) {
+            result.add(new InvalidProperty(SettingsConst.PROP_CONST_BUILD_PARAMETERS, Dictionary.ERROR_INVALID_PROPERTIES));
         }
 
         return result;


### PR DESCRIPTION
This `catch` help to identify root cause of behavior from #14 preventing UI from showing long stack trace and show not settled pamas instead